### PR TITLE
[GITHUB-11] feat: no mas de un evento en un mismo slot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ npm run build:next              # Build Next.js only (skip migrations, lint, for
 npm start                       # Run production server
 
 # Docker
-docker compose -f docker/docker-compose.yml up --build          # Start full stack
+docker compose -f docker/docker-compose.yml up --build          # Start full stack (app on :3000)
+APP_PORT=3001 docker compose -f docker/docker-compose.yml up --build  # Use a different host port
 docker compose -f docker/docker-compose.yml up postgres mailpit # Infra only (no app container)
 docker compose -f docker/docker-compose.yml down -v             # Stop and remove volumes
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - ../:/app
       - app_node_modules:/app/node_modules
     ports:
-      - "3000:3000"
+      - "${APP_PORT:-3000}:3000"
       - "9229:9229"
     env_file:
       - ../.env

--- a/prisma/migrations/20260610000000_cross_resource_overlap_check/migration.sql
+++ b/prisma/migrations/20260610000000_cross_resource_overlap_check/migration.sql
@@ -1,0 +1,375 @@
+-- Prevent a reservable entity from holding overlapping APPROVED reservations
+-- across different resources. The check is generic: it operates on
+-- (reservable_id, reservable_type) without referencing any specific resource type.
+--
+-- Changes:
+--  1. Index on reservation_ledger(reservable_id, reservable_type, status) to make
+--     the cross-resource lookup fast.
+--  2. create_reservation() gains a cross-resource overlap guard (non-recurring and
+--     per-occurrence for recurring).
+--  3. approve_reservation() gains a second auto-reject loop that rejects PENDING
+--     reservations of the same reservable on *different* resources when they overlap
+--     the just-approved reservation.
+
+-- ============================================================================
+-- Index for cross-resource lookups by reservable entity
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS reservation_ledger_reservable_status_idx
+  ON reservation_ledger (reservable_id, reservable_type, status);
+
+-- ============================================================================
+CREATE OR REPLACE FUNCTION create_reservation(
+  _reservation_id text,
+  _reservable_type reservable_types,
+  _reservable_id text,
+  _resource_type resource_types,
+  _event_type event_types,
+  _reason text,
+  _start_ms bigint,
+  _end_ms bigint,
+  _is_recurring boolean DEFAULT false,
+  _rrule text DEFAULT NULL,
+  _recurrence_end_ms bigint DEFAULT NULL
+)
+RETURNS void AS $$
+DECLARE
+  actor_size int;
+  chosen_resource text;
+  cap int;
+  exclusive boolean;
+  overlap int;
+  occ_ms bigint;
+  duration_ms bigint;
+  recurrence_cap_ms bigint;
+  year_cap_ms bigint;
+  step_interval interval;
+  now_ms bigint;
+  omit boolean;
+  win_s bigint;
+  win_e bigint;
+  conflict_resource_name text;
+  conflict_resource_type text;
+BEGIN
+  now_ms := (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint;
+  duration_ms := _end_ms - _start_ms;
+  IF duration_ms <= 0 THEN
+    RAISE EXCEPTION 'Invalid reservation window';
+  END IF;
+
+  year_cap_ms := 365::bigint * 86400000;
+
+  SELECT get_actor_size(_reservable_type, _reservable_id)
+  INTO actor_size;
+
+  FOR chosen_resource, cap, exclusive IN
+    SELECT
+      r.id,
+      COALESCE(fr.capacity, 1) AS capacity,
+      COALESCE(fr.is_exclusive, true) AS is_exclusive
+    FROM resources r
+    LEFT JOIN fungible_resources fr ON fr.id = r.fungible_resource_id
+    WHERE r.type = _resource_type
+    ORDER BY r.id
+  LOOP
+    IF exclusive THEN
+      SELECT COUNT(*) INTO overlap
+      FROM reservation_ledger l
+      WHERE l.resource_id = chosen_resource
+        AND l.status = 'APPROVED'
+        AND l.occurrence_start_time < _end_ms
+        AND l.occurrence_end_time > _start_ms;
+
+      IF overlap = 0 THEN
+        EXIT;
+      END IF;
+
+    ELSE
+      SELECT COALESCE(MAX(slot_sum), 0)
+        INTO overlap
+      FROM (
+        SELECT COALESCE((
+                 SELECT SUM(l.actor_size)
+                 FROM reservation_ledger l
+                 WHERE l.resource_id = chosen_resource
+                   AND l.status = 'APPROVED'
+                   AND l.occurrence_start_time = gs
+               ), 0) AS slot_sum
+        FROM generate_series(_start_ms, _end_ms - 1, 900000::bigint) AS gs
+        WHERE gs < _end_ms
+      ) slot_check;
+
+      IF (overlap + actor_size) <= cap THEN
+        EXIT;
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF chosen_resource IS NULL THEN
+    RAISE EXCEPTION 'No available % resource for the given time window', _resource_type;
+  END IF;
+
+  IF NOT _is_recurring THEN
+    -- Cross-resource overlap guard: same reservable cannot have overlapping APPROVED reservations
+    SELECT r.name, r.type::text
+    INTO conflict_resource_name, conflict_resource_type
+    FROM reservation_ledger l
+    JOIN resources r ON r.id = l.resource_id
+    WHERE l.reservable_id   = _reservable_id
+      AND l.reservable_type = _reservable_type
+      AND l.status          = 'APPROVED'
+      AND l.occurrence_start_time < _end_ms
+      AND l.occurrence_end_time   > _start_ms
+    LIMIT 1;
+    IF conflict_resource_name IS NOT NULL THEN
+      RAISE EXCEPTION 'Overlap with approved reservation at % (%)', conflict_resource_name, conflict_resource_type;
+    END IF;
+
+    INSERT INTO reservations (
+      id, reservable_type, reservable_id, resource_id,
+      event_type, reason, start_time, end_time,
+      is_recurring, rrule, recurrence_end, status,
+      created_at, updated_at
+    )
+    VALUES (
+      _reservation_id, _reservable_type, _reservable_id, chosen_resource,
+      _event_type, _reason, _start_ms, _end_ms,
+      false, NULL, NULL, 'PENDING',
+      now_ms, now_ms
+    );
+
+    PERFORM insert_into_ledger(_reservation_id, _start_ms, _end_ms, _reservable_type, _reservable_id, chosen_resource, _event_type, _reason, actor_size, 'PENDING');
+
+    RETURN;
+  END IF;
+
+  INSERT INTO reservations (
+    id, reservable_type, reservable_id, resource_id,
+    event_type, reason, start_time, end_time,
+    is_recurring, rrule, recurrence_end, status,
+    created_at, updated_at
+  )
+  VALUES (
+    _reservation_id, _reservable_type, _reservable_id, chosen_resource,
+    _event_type, _reason, _start_ms, _end_ms,
+    true, _rrule, _recurrence_end_ms, 'PENDING',
+    now_ms, now_ms
+  );
+
+  IF _rrule ILIKE '%DAILY%' THEN
+    step_interval := interval '1 day';
+  ELSIF _rrule ILIKE '%WEEKLY%' THEN
+    step_interval := interval '1 week';
+  ELSIF _rrule ILIKE '%MONTHLY%' THEN
+    step_interval := interval '1 month';
+  ELSIF _rrule ILIKE '%YEARLY%' THEN
+    step_interval := interval '1 year';
+  ELSE
+    step_interval := interval '1 day';
+  END IF;
+
+  recurrence_cap_ms := LEAST(
+    COALESCE(_recurrence_end_ms, _start_ms + year_cap_ms),
+    _start_ms + year_cap_ms
+  );
+
+  occ_ms := _start_ms;
+  WHILE occ_ms <= recurrence_cap_ms LOOP
+    SELECT * INTO omit, win_s, win_e
+    FROM effective_occurrence_window(_reservation_id, occ_ms, duration_ms);
+
+    IF NOT omit THEN
+      IF exclusive THEN
+        SELECT COUNT(*) INTO overlap
+        FROM reservation_ledger l
+        WHERE l.resource_id = chosen_resource
+          AND l.status = 'APPROVED'
+          AND l.occurrence_start_time < win_e
+          AND l.occurrence_end_time > win_s;
+
+        IF overlap > 0 THEN
+          RAISE EXCEPTION 'Conflict on %', occ_ms;
+        END IF;
+      ELSE
+        SELECT COALESCE(MAX(slot_sum), 0) INTO overlap
+        FROM (
+          SELECT COALESCE((
+                   SELECT SUM(l.actor_size)
+                   FROM reservation_ledger l
+                   WHERE l.resource_id = chosen_resource
+                     AND l.status = 'APPROVED'
+                     AND l.occurrence_start_time = gs
+                 ), 0) AS slot_sum
+          FROM generate_series(win_s, win_e - 1, 900000::bigint) AS gs
+          WHERE gs < win_e
+        ) slot_check;
+
+        IF (overlap + actor_size) > cap THEN
+          RAISE EXCEPTION 'Capacity exceeded on %', occ_ms;
+        END IF;
+      END IF;
+
+      -- Cross-resource overlap guard per occurrence
+      SELECT r.name, r.type::text
+      INTO conflict_resource_name, conflict_resource_type
+      FROM reservation_ledger l
+      JOIN resources r ON r.id = l.resource_id
+      WHERE l.reservable_id   = _reservable_id
+        AND l.reservable_type = _reservable_type
+        AND l.status          = 'APPROVED'
+        AND l.occurrence_start_time < win_e
+        AND l.occurrence_end_time   > win_s
+      LIMIT 1;
+      IF conflict_resource_name IS NOT NULL THEN
+        RAISE EXCEPTION 'Overlap with approved reservation at % (%) on occurrence %', conflict_resource_name, conflict_resource_type, occ_ms;
+      END IF;
+
+      PERFORM insert_into_ledger(_reservation_id, win_s, win_e, _reservable_type, _reservable_id, chosen_resource, _event_type, _reason, actor_size, 'PENDING');
+    END IF;
+
+    EXIT WHEN occ_ms >= recurrence_cap_ms;
+    occ_ms := (EXTRACT(EPOCH FROM (to_timestamp(occ_ms / 1000.0) + step_interval)) * 1000)::bigint;
+    IF occ_ms <= _start_ms THEN
+      EXIT;
+    END IF;
+  END LOOP;
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+CREATE OR REPLACE FUNCTION approve_reservation(_reservation_id text)
+RETURNS TABLE(approved_id text, auto_rejected_ids text) AS $$
+DECLARE
+  res RECORD;
+  cap int;
+  exclusive boolean;
+  used int;
+  overlap RECORD;
+  rejected_ids text[];
+  now_ms bigint;
+BEGIN
+  now_ms := (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint;
+  rejected_ids := ARRAY[]::text[];
+
+  SELECT r.id AS reservation_id,
+         r.resource_id,
+         r.reservable_id,
+         r.reservable_type,
+         r.start_time,
+         r.end_time,
+         COALESCE(fr.capacity, 1) AS capacity,
+         COALESCE(fr.is_exclusive, true) AS is_exclusive
+  INTO res
+  FROM reservations r
+  LEFT JOIN fungible_resources fr ON fr.id = (
+    SELECT fungible_resource_id FROM resources WHERE id = r.resource_id
+  )
+  WHERE r.id = _reservation_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Reservation % not found', _reservation_id;
+  END IF;
+
+  cap := res.capacity;
+  exclusive := res.is_exclusive;
+
+  UPDATE reservations
+    SET status = 'APPROVED', updated_at = now_ms
+    WHERE id = _reservation_id;
+
+  UPDATE reservation_ledger
+    SET status = 'APPROVED'
+    WHERE reservation_id = _reservation_id;
+
+  -- Auto-reject conflicting PENDING reservations on the same resource
+  FOR overlap IN
+    SELECT DISTINCT rl.reservation_id
+    FROM reservation_ledger rl
+    WHERE rl.resource_id = res.resource_id
+      AND rl.status = 'PENDING'
+      AND rl.reservation_id <> _reservation_id
+      AND EXISTS (
+        SELECT 1
+        FROM reservation_ledger a
+        WHERE a.reservation_id = _reservation_id
+          AND a.resource_id = res.resource_id
+          AND a.status = 'APPROVED'
+          AND rl.occurrence_start_time < a.occurrence_end_time
+          AND rl.occurrence_end_time > a.occurrence_start_time
+      )
+  LOOP
+    IF exclusive THEN
+      UPDATE reservations SET status = 'REJECTED', updated_at = now_ms
+        WHERE id = overlap.reservation_id;
+      UPDATE reservation_ledger SET status = 'REJECTED'
+        WHERE reservation_id = overlap.reservation_id;
+      rejected_ids := array_append(rejected_ids, overlap.reservation_id);
+    ELSE
+      SELECT COALESCE(MAX(approved_at_slot + p_actor_size), 0)
+      INTO used
+      FROM (
+        SELECT p.occurrence_start_time,
+               p.actor_size AS p_actor_size,
+               COALESCE((
+                 SELECT SUM(a.actor_size)
+                 FROM reservation_ledger a
+                 WHERE a.resource_id = res.resource_id
+                   AND a.status = 'APPROVED'
+                   AND a.occurrence_start_time = p.occurrence_start_time
+               ), 0) AS approved_at_slot
+        FROM reservation_ledger p
+        WHERE p.reservation_id = overlap.reservation_id
+          AND p.status = 'PENDING'
+          AND EXISTS (
+            SELECT 1
+            FROM reservation_ledger a
+            WHERE a.reservation_id = _reservation_id
+              AND a.status = 'APPROVED'
+              AND a.resource_id = res.resource_id
+              AND p.occurrence_start_time < a.occurrence_end_time
+              AND p.occurrence_end_time > a.occurrence_start_time
+          )
+      ) slot_check;
+
+      IF used > cap THEN
+        UPDATE reservations
+          SET status = 'REJECTED', updated_at = now_ms
+          WHERE id = overlap.reservation_id;
+
+        UPDATE reservation_ledger
+          SET status = 'REJECTED'
+          WHERE reservation_id = overlap.reservation_id;
+        rejected_ids := array_append(rejected_ids, overlap.reservation_id);
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Auto-reject PENDING reservations of the same reservable on different resources
+  -- that overlap the just-approved reservation (cross-resource conflict enforcement).
+  FOR overlap IN
+    SELECT DISTINCT rl.reservation_id
+    FROM reservation_ledger rl
+    WHERE rl.reservable_id   = res.reservable_id
+      AND rl.reservable_type = res.reservable_type
+      AND rl.status          = 'PENDING'
+      AND rl.reservation_id <> _reservation_id
+      AND rl.resource_id    <> res.resource_id
+      AND EXISTS (
+        SELECT 1
+        FROM reservation_ledger a
+        WHERE a.reservation_id = _reservation_id
+          AND a.status         = 'APPROVED'
+          AND rl.occurrence_start_time < a.occurrence_end_time
+          AND rl.occurrence_end_time   > a.occurrence_start_time
+      )
+  LOOP
+    UPDATE reservations SET status = 'REJECTED', updated_at = now_ms
+      WHERE id = overlap.reservation_id;
+    UPDATE reservation_ledger SET status = 'REJECTED'
+      WHERE reservation_id = overlap.reservation_id;
+    rejected_ids := array_append(rejected_ids, overlap.reservation_id);
+  END LOOP;
+
+  RETURN QUERY SELECT _reservation_id, array_to_string(rejected_ids, ',');
+END;
+$$ LANGUAGE plpgsql;

--- a/src/components/organisms/calendar/WeekCalendar.tsx
+++ b/src/components/organisms/calendar/WeekCalendar.tsx
@@ -60,10 +60,13 @@ function isBookableReservationDay(day: Date, clock: Date): boolean {
   return isAfter(startOfDay(day), startOfDay(clock));
 }
 
+export type UnavailableSlotKind = "resource_full" | "cross_resource";
+
 export interface UnavailableSlot {
   resourceId?: string;
   startTime: number;
   endTime: number;
+  kind?: UnavailableSlotKind;
 }
 
 export interface DragSelection {
@@ -227,6 +230,7 @@ export function WeekCalendar({
         ) ||
         occurrences.some(
           (occ) =>
+            (occ.status === "PENDING" || occ.status === "APPROVED") &&
             isSameDay(fromUtcMs(occ.occurrenceStartTime), day) &&
             ((startMinutes > getMinutes(fromUtcMs(occ.occurrenceStartTime)) &&
               endMinutes < getMinutes(fromUtcMs(occ.occurrenceEndTime))) ||
@@ -257,8 +261,11 @@ export function WeekCalendar({
           let current = rawSlots[0];
           for (let i = 1; i < rawSlots.length; i++) {
             const slot = rawSlots[i];
-            if (current.endTime === slot.startTime) {
-              current.endTime = slot.endTime;
+            if (
+              current.endTime === slot.startTime &&
+              current.kind === slot.kind
+            ) {
+              current = { ...current, endTime: slot.endTime };
             } else {
               processedUnavailableSlots.push(current);
               current = slot;
@@ -789,13 +796,17 @@ export function WeekCalendar({
                           startTime: slot.startTime,
                           endTime: slot.endTime,
                         });
+                        const stripeClass =
+                          slot.kind === "cross_resource"
+                            ? "h-full rounded bg-[repeating-linear-gradient(135deg,_#7c3aed_0,_#7c3aed_3px,_transparent_0,_transparent_50%)] dark:bg-[repeating-linear-gradient(135deg,_#a78bfa_0,_#a78bfa_3px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed"
+                            : "h-full rounded bg-[repeating-linear-gradient(135deg,_#99a1af_0,_#99a1af_3px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed";
                         return (
                           <div
                             key={idx}
-                            className="absolute w-full bg-red z-50"
+                            className="absolute w-full z-50"
                             style={{ top: style.top, height: style.height }}
                           >
-                            <div className="h-full rounded bg-[repeating-linear-gradient(135deg,_#99a1af_0,_#99a1af_3px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed" />
+                            <div className={stripeClass} />
                           </div>
                         );
                       })}
@@ -811,14 +822,19 @@ export function WeekCalendar({
                         occ.reservableType === "USER" &&
                         occ.reservableId === userId;
                       const isPending = occ.status === "PENDING";
+                      const isRejected = occ.status === "REJECTED";
+                      const isCancelled = occ.status === "CANCELLED";
 
-                      // Visual styling based on reservation ownership and status
                       const bgColor =
                         isOwnReservation && isPending
-                          ? "bg-yellow-500" // User's pending reservation (yellow)
-                          : isOwnReservation
-                            ? "bg-green-600" // User's approved reservation (green)
-                            : "bg-la-nube-primary"; // Other's approved reservation (blue)
+                          ? "bg-yellow-500"
+                          : isOwnReservation && isRejected
+                            ? "bg-red-600"
+                            : isOwnReservation && isCancelled
+                              ? "bg-gray-500"
+                              : isOwnReservation
+                                ? "bg-green-600"
+                                : "bg-la-nube-primary";
 
                       return (
                         <div
@@ -828,13 +844,16 @@ export function WeekCalendar({
                         >
                           <div
                             className={`h-full rounded ${bgColor} text-white text-xs p-1 overflow-hidden cursor-pointer shadow-sm`}
-                            title={`${occ.reason} ${isOwnReservation ? "(Tu reserva)" : ""} ${isPending ? "(Pendiente)" : ""}`}
+                            title={`${occ.reason} ${isOwnReservation ? "(Tu reserva)" : ""} ${isPending ? "(Pendiente)" : isRejected ? "(Rechazada)" : isCancelled ? "(Cancelada)" : ""}`}
                             onClick={() => setSelectedOccurrence(occ)}
                           >
                             <div className="font-semibold truncate">
                               {occ.reason}
-                              {isOwnReservation && (
-                                <span className="ml-1">✓</span>
+                              {isOwnReservation &&
+                                !isRejected &&
+                                !isCancelled && <span className="ml-1">✓</span>}
+                              {isOwnReservation && isRejected && (
+                                <span className="ml-1">✗</span>
                               )}
                             </div>
                             <div className="text-[10px] opacity-90">

--- a/src/lib/db/reservations.ts
+++ b/src/lib/db/reservations.ts
@@ -192,6 +192,14 @@ export async function createReservation(
           "No hay recursos disponibles para el horario seleccionado",
         );
       }
+      const overlapMatch = error.message?.match(
+        /Overlap with approved reservation at (.+?) \(/,
+      );
+      if (overlapMatch) {
+        throw new Error(
+          `Ya tenés una reserva aprobada en "${overlapMatch[1]}" en ese horario`,
+        );
+      }
       if (error.message?.includes("Conflict on")) {
         throw new Error("Conflicto en una de las fechas de la recurrencia");
       }
@@ -865,7 +873,7 @@ export async function getUserNextReservations(
   >`
     SELECT * FROM get_user_next_reservations(
       ${userId}::text,
-      ${resourceType}::resource_types,
+      ${resourceType ?? null}::resource_types,
       ${limit}::int,
       ${offset}::int
     )

--- a/src/lib/db/resourceCalendar.ts
+++ b/src/lib/db/resourceCalendar.ts
@@ -17,10 +17,14 @@ export interface ReservationOccurrence {
   reservableId: string;
 }
 
+/** Why a time slot is unavailable. Extend this union for new blocking reasons. */
+export type UnavailableSlotKind = "resource_full" | "cross_resource";
+
 export interface CalendarUnavailableSlot {
   resourceId: string;
   startTime: number;
   endTime: number;
+  kind: UnavailableSlotKind;
 }
 
 /** Returns the RegisteredUser ID for a given account email, or null. */
@@ -48,39 +52,76 @@ export async function getCalendarDataByType(
   const rangeStartMs = dateToUnixMs(startDate);
   const rangeEndMs = dateToUnixMs(endDate);
 
-  const unavailableSlots = await getUnavailableSlots(
-    resourceType,
-    startDate,
-    endDate,
-    userId,
-  );
+  const [unavailableSlotsRaw, allUserReservations] = await Promise.all([
+    getUnavailableSlots(resourceType, startDate, endDate, userId),
+    getUserNextReservations(userId, undefined, 100, 0),
+  ]);
 
-  const allUserReservations = await getUserNextReservations(
-    userId,
-    resourceType,
-    100,
-    0,
-  );
+  // Resolve each reservation's resource type so we can split:
+  //   - same resource type  -> show as a reservation card
+  //   - different resource type (PENDING/APPROVED) -> block the slot (cross_resource)
+  const uniqueResourceIds = [
+    ...new Set(
+      allUserReservations
+        .map((r) => r.resourceId)
+        .filter((id): id is string => id !== null),
+    ),
+  ];
+  const resourceTypeMap = new Map<string, ResourceType>();
+  if (uniqueResourceIds.length > 0) {
+    const resources = await prisma.resource.findMany({
+      where: { id: { in: uniqueResourceIds } },
+      select: { id: true, type: true },
+    });
+    for (const r of resources) {
+      resourceTypeMap.set(r.id, r.type);
+    }
+  }
 
-  const userReservations = allUserReservations.filter((res) => {
-    const t = res.occurrenceStartTime;
-    return t >= rangeStartMs && t <= rangeEndMs;
-  });
+  const userReservations: ReservationOccurrence[] = [];
+  const crossResourceSlots: CalendarUnavailableSlot[] = [];
+
+  for (const res of allUserReservations) {
+    const ms = Number(res.occurrenceStartTime);
+    if (ms < rangeStartMs || ms > rangeEndMs) continue;
+
+    const resType = res.resourceId
+      ? resourceTypeMap.get(res.resourceId)
+      : undefined;
+
+    if (resType === resourceType) {
+      userReservations.push({
+        reservationId: res.id,
+        occurrenceStartTime: Number(res.occurrenceStartTime),
+        occurrenceEndTime: Number(res.occurrenceEndTime),
+        reason: res.reason ?? "",
+        status: res.status,
+        reservableType: res.reservableType as ReservableType,
+        reservableId: res.reservableId,
+      });
+    } else if (
+      resType !== undefined &&
+      (res.status === "PENDING" || res.status === "APPROVED")
+    ) {
+      crossResourceSlots.push({
+        resourceId: res.resourceId ?? "",
+        startTime: Number(res.occurrenceStartTime),
+        endTime: Number(res.occurrenceEndTime),
+        kind: "cross_resource",
+      });
+    }
+  }
 
   return {
-    unavailableSlots: unavailableSlots.map((s) => ({
-      resourceId: s.resourceId,
-      startTime: Number(s.startTime),
-      endTime: Number(s.endTime),
-    })),
-    userReservations: userReservations.map((res) => ({
-      reservationId: res.id,
-      occurrenceStartTime: Number(res.occurrenceStartTime),
-      occurrenceEndTime: Number(res.occurrenceEndTime),
-      reason: res.reason ?? "",
-      status: res.status,
-      reservableType: res.reservableType as ReservableType,
-      reservableId: res.reservableId,
-    })),
+    unavailableSlots: [
+      ...unavailableSlotsRaw.map((s) => ({
+        resourceId: s.resourceId,
+        startTime: Number(s.startTime),
+        endTime: Number(s.endTime),
+        kind: "resource_full" as UnavailableSlotKind,
+      })),
+      ...crossResourceSlots,
+    ],
+    userReservations,
   };
 }


### PR DESCRIPTION
Antes, un usuario podia hacer reservas para dos recursos diferentes en un mismo time slot.
Eso no es lo que queremos, porque un usuario no deberia estar en dos lugares a la vez.

Este cambio previene eso.

Tambien hice un par de cambios al docker compose (menores), para permitir usar otro puerto para la app, en caso de que el puerto 3000 (default) ya este en uso